### PR TITLE
Adds Symfony YAML class as required dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
   ],
   "require": {
     "php": ">=5.3.3",
-    "symfony/config": "2.6.3"
+    "symfony/config": "2.6.3",
+    "symfony/yaml": "~2"
   },
   "require-dev": {
     "phpunit/phpunit": "4.2.*",


### PR DESCRIPTION
ConfigReader.php requires the Symfony YAML class, which is not included as a dependency in the composer.json file.