### PR TITLE
Updated symfony requirements for 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
   ],
   "require": {
     "php": ">=5.3.3",
-    "symfony/config": "2.6.3",
+    "symfony/config": "2.3.*",
     "symfony/yaml": "~2"
   },
   "require-dev": {
     "phpunit/phpunit": "4.2.*",
-    "symfony/debug": "2.6.3",
-    "symfony/var-dumper": "2.6.3"
+    "symfony/debug": "2.3.*",
+    "symfony/var-dumper": "2.3.*"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
I've updated the requirements to require symfony 2.3, since it's a long term release. Will this work for sF 2.3? Also, I don't know if the composer.lock should be updated too.